### PR TITLE
WIP: Swap text segments on tutorial

### DIFF
--- a/views/tutorial.rb
+++ b/views/tutorial.rb
@@ -86,14 +86,14 @@ module Views
 
     def render_phase_4
       render_segment do
-        text 'Turn order is determined now by remaining cash. If tied, relative turn order is maintained'
+        text 'The foreign investor will purchase the cheapest company if available for face value.'
+        text 'This keeps the game moving in case no one buys anything.'
       end
     end
 
     def render_phase_5
       render_segment do
-        text 'The foreign investor will purchase the cheapest company if available for face value.'
-        text 'This keeps the game moving in case no one buys anything.'
+        text 'Turn order is determined now by remaining cash. If tied, relative turn order is maintained'
       end
     end
 

--- a/views/tutorial.rb
+++ b/views/tutorial.rb
@@ -93,7 +93,7 @@ module Views
 
     def render_phase_5
       render_segment do
-        text 'Turn order is determined now by remaining cash. If tied, relative turn order is maintained'
+        text 'Turn order is determined now by remaining cash. If tied, relative turn order is maintained.'
       end
     end
 


### PR DESCRIPTION
The text for phases 4 and 5 were backwards, as noted by `luigicool` in the chat today.